### PR TITLE
[EX-637] add warning for missing kotlin type metadata in external djinni yaml files

### DIFF
--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -353,9 +353,11 @@ object Main {
       }
     }
 
+    val yamlOptions = YamlOptions(kotlinWarnings = kotlinOutFolder.isDefined)
+
     // Resolve names in IDL file, check types.
     System.out.println("Resolving...")
-    resolver.resolve(meta.defaults, idl) match {
+    resolver.resolve(meta.defaults, idl, yamlOptions) match {
       case Some(err) =>
         System.err.println(err)
         System.exit(1); return

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -353,7 +353,7 @@ object Main {
       }
     }
 
-    val yamlOptions = YamlOptions(kotlinWarnings = kotlinOutFolder.isDefined)
+    val yamlOptions = YamlOptions(enableKotlinWarnings = kotlinOutFolder.isDefined)
 
     // Resolve names in IDL file, check types.
     System.out.println("Resolving...")

--- a/src/source/YamlGenerator.scala
+++ b/src/source/YamlGenerator.scala
@@ -298,7 +298,13 @@ object YamlGenerator {
     try {
       nested(td, key)(subKey).toString
     } catch {
-      case e: java.util.NoSuchElementException => "[unspecified]"
+      case e: java.util.NoSuchElementException =>
+        key match {
+          case "kotlin" => println("Warning: Kotlin type not specified for " + td.ident.name)
+          case _ =>
+        }
+
+        "[unspecified]"
     }
   }
 

--- a/src/source/YamlGenerator.scala
+++ b/src/source/YamlGenerator.scala
@@ -18,16 +18,14 @@
 
 package djinni
 
-import djinni.ast._
-import djinni.ast.Record.DerivingType.DerivingType
-import djinni.generatorTools._
-import djinni.meta._
-import djinni.writer.IndentWriter
+import ast._
+import generatorTools._
+import meta._
+import writer.IndentWriter
 import java.util.{Map => JMap}
 import scala.collection.JavaConversions._
-import scala.collection.mutable
 
-case class YamlOptions(kotlinWarnings: Boolean)
+case class YamlOptions(enableKotlinWarnings: Boolean)
 
 class YamlGenerator(spec: Spec) extends Generator(spec) {
 
@@ -274,8 +272,8 @@ object YamlGenerator {
       nested(td, "jni")("typename").toString,
       nested(td, "jni")("typeSignature").toString),
     MExtern.Kotlin(
-      getOptionalField(td, "kotlin", "typename", warnIfMissing = yamlOptions.kotlinWarnings),
-      getOptionalFieldWithDefault(td, "kotlin", "isProtobufMessage", false, warnIfMissing = yamlOptions.kotlinWarnings)),
+      getOptionalField(td, "kotlin", "typename", warnIfMissing = yamlOptions.enableKotlinWarnings),
+      getOptionalFieldWithDefault(td, "kotlin", "isProtobufMessage", false, warnIfMissing = yamlOptions.enableKotlinWarnings)),
     MExtern.Wasm(
       getOptionalField(td, "wasm", "typename"),
       getOptionalField(td, "wasm", "translator"),
@@ -294,7 +292,7 @@ object YamlGenerator {
     if (nested(td, key) contains subKey)
       nested(td, key)(subKey).asInstanceOf[T]
     else {
-      if(warnIfMissing) println(s"Warning: $key: ${td.ident.name} has unspecified $subKey")
+      if(warnIfMissing) println(s"Warning: ${td.ident.name}: $key: $subKey is unspecified")
       defVal
     }
   }
@@ -304,7 +302,7 @@ object YamlGenerator {
       nested(td, key)(subKey).toString
     } catch {
       case e: java.util.NoSuchElementException =>
-        if(warnIfMissing) println(s"Warning: $key: ${td.ident.name} has unspecified $subKey")
+        if(warnIfMissing) println(s"Warning: ${td.ident.name}: $key: $subKey is unspecified")
 
         "[unspecified]"
     }

--- a/src/source/YamlGenerator.scala
+++ b/src/source/YamlGenerator.scala
@@ -27,6 +27,8 @@ import java.util.{Map => JMap}
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 
+case class YamlOptions(kotlinWarnings: Boolean)
+
 class YamlGenerator(spec: Spec) extends Generator(spec) {
 
   val cppMarshal = new CppMarshal(spec)
@@ -37,7 +39,7 @@ class YamlGenerator(spec: Spec) extends Generator(spec) {
   val wasmMarshal = new WasmGenerator(spec)
   val tsMarshal = new TsGenerator(spec)
 
-  case class QuotedString(str: String) // For anything that migt require escaping
+  case class QuotedString(str: String) // For anything that might require escaping
 
   private def writeYamlFile(name: String, origin: String, f: IndentWriter => Unit): Unit = {
     createFile(spec.yamlOutFolder.get, name, out => new IndentWriter(out, "  "), w => {
@@ -237,7 +239,7 @@ class YamlGenerator(spec: Spec) extends Generator(spec) {
 }
 
 object YamlGenerator {
-  def metaFromYaml(td: ExternTypeDecl) = MExtern(
+  def metaFromYaml(td: ExternTypeDecl, yamlOptions: YamlOptions) = MExtern(
     td.ident.name.stripPrefix(td.properties("prefix").toString), // Make sure the generator uses this type with its original name for all intents and purposes
     td.params.size,
     defType(td),
@@ -246,15 +248,15 @@ object YamlGenerator {
       nested(td, "cpp")("typename").toString,
       nested(td, "cpp")("header").toString,
       nested(td, "cpp")("byValue").asInstanceOf[Boolean],
-      getOptionalField(td, "cpp", "moveOnly", false)),
+      getOptionalFieldWithDefault(td, "cpp", "moveOnly", false)),
     MExtern.Objc(
       nested(td, "objc")("typename").toString,
       nested(td, "objc")("header").toString,
       nested(td, "objc")("boxed").toString,
       nested(td, "objc")("pointer").asInstanceOf[Boolean],
-      getOptionalField(td, "objc", "generic", false),
+      getOptionalFieldWithDefault(td, "objc", "generic", false),
       nested(td, "objc")("hash").toString,
-      getOptionalField(td, "objc", "protocol", false)),
+      getOptionalFieldWithDefault(td, "objc", "protocol", false)),
     MExtern.Objcpp(
       nested(td, "objcpp")("translator").toString,
       nested(td, "objcpp")("header").toString),
@@ -264,16 +266,16 @@ object YamlGenerator {
       nested(td, "java")("reference").asInstanceOf[Boolean],
       nested(td, "java")("generic").asInstanceOf[Boolean],
       nested(td, "java")("hash").toString,
-      getOptionalField(td, "java", "writeToParcel", "%s.writeToParcel(out, flags)"),
-      getOptionalField(td, "java", "readFromParcel", "new %s(in)")),
+      getOptionalFieldWithDefault(td, "java", "writeToParcel", "%s.writeToParcel(out, flags)"),
+      getOptionalFieldWithDefault(td, "java", "readFromParcel", "new %s(in)")),
     MExtern.Jni(
       nested(td, "jni")("translator").toString,
       nested(td, "jni")("header").toString,
       nested(td, "jni")("typename").toString,
       nested(td, "jni")("typeSignature").toString),
     MExtern.Kotlin(
-      getOptionalField(td, "kotlin", "typename"),
-      getOptionalField(td, "kotlin", "isProtobufMessage", false)),
+      getOptionalField(td, "kotlin", "typename", warnIfMissing = yamlOptions.kotlinWarnings),
+      getOptionalFieldWithDefault(td, "kotlin", "isProtobufMessage", false, warnIfMissing = yamlOptions.kotlinWarnings)),
     MExtern.Wasm(
       getOptionalField(td, "wasm", "typename"),
       getOptionalField(td, "wasm", "translator"),
@@ -281,28 +283,28 @@ object YamlGenerator {
     MExtern.Ts(
       getOptionalField(td, "ts", "typename"),
       getOptionalField(td, "ts", "module"),
-      getOptionalField(td, "ts", "generic", false))
+      getOptionalFieldWithDefault(td, "ts", "generic", false))
   )
 
   private def nested(td: ExternTypeDecl, key: String) = {
     td.properties.get(key).collect { case m: JMap[_, _] => m.collect { case (k: String, v: Any) => (k, v) } } getOrElse(Map[String, Any]())
   }
 
-  private def getOptionalField[T](td: ExternTypeDecl, key: String, subKey: String, defVal: T) = {
+  private def getOptionalFieldWithDefault[T](td: ExternTypeDecl, key: String, subKey: String, defVal: T, warnIfMissing: Boolean = false) = {
     if (nested(td, key) contains subKey)
       nested(td, key)(subKey).asInstanceOf[T]
-    else defVal
+    else {
+      if(warnIfMissing) println(s"Warning: $key: ${td.ident.name} has unspecified $subKey")
+      defVal
+    }
   }
 
-  private def getOptionalField(td: ExternTypeDecl, key: String, subKey: String) = {
+  private def getOptionalField(td: ExternTypeDecl, key: String, subKey: String, warnIfMissing: Boolean = false) = {
     try {
       nested(td, key)(subKey).toString
     } catch {
       case e: java.util.NoSuchElementException =>
-        key match {
-          case "kotlin" => println("Warning: Kotlin type not specified for " + td.ident.name)
-          case _ =>
-        }
+        if(warnIfMissing) println(s"Warning: $key: ${td.ident.name} has unspecified $subKey")
 
         "[unspecified]"
     }

--- a/src/source/resolver.scala
+++ b/src/source/resolver.scala
@@ -18,14 +18,10 @@
 
 package djinni
 
-import java.util
-import djinni.ast.Record.DerivingType
-import djinni.ast.Record.DerivingType.DerivingType
-import djinni.ast.Record.DerivingType.DerivingType
-import djinni.syntax._
-import djinni.ast._
-import djinni.generatorTools.Spec
-import djinni.meta._
+import ast.Record.DerivingType
+import syntax._
+import ast._
+import meta._
 
 import scala.collection.immutable
 import scala.collection.mutable

--- a/src/source/resolver.scala
+++ b/src/source/resolver.scala
@@ -19,13 +19,14 @@
 package djinni
 
 import java.util
-
 import djinni.ast.Record.DerivingType
 import djinni.ast.Record.DerivingType.DerivingType
 import djinni.ast.Record.DerivingType.DerivingType
 import djinni.syntax._
 import djinni.ast._
+import djinni.generatorTools.Spec
 import djinni.meta._
+
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -34,7 +35,7 @@ package object resolver {
 
 type Scope = immutable.Map[String,Meta]
 
-def resolve(metas: Scope, idl: Seq[TypeDecl]): Option[Error] = {
+def resolve(metas: Scope, idl: Seq[TypeDecl], yamlOptions: YamlOptions): Option[Error] = {
 
   try {
     var topScope = metas
@@ -56,7 +57,7 @@ def resolve(metas: Scope, idl: Seq[TypeDecl]): Option[Error] = {
       }
       topScope = topScope.updated(typeDecl.ident.name, typeDecl match {
         case td: InternTypeDecl => MDef(typeDecl.ident.name, typeDecl.params.length, defType, typeDecl.body)
-        case td: ExternTypeDecl => YamlGenerator.metaFromYaml(td)
+        case td: ExternTypeDecl => YamlGenerator.metaFromYaml(td, yamlOptions)
         case td: ProtobufTypeDecl => MProtobuf(td.ident.name, 0, td.body.asInstanceOf[ProtobufMessage])
       })
     }


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

Adds warning when parsing external type yaml files if djinni has been asked to generate kotlin bindings but external types  are missing kotlin type metadata.

<img width="1775" height="1191" alt="Screenshot 2025-07-23 at 5 26 25 pm" src="https://github.com/user-attachments/assets/860aecd6-4d56-4f8c-8c48-a610c891d6a0" />
